### PR TITLE
Fix issues with non-integer padding and center indices

### DIFF
--- a/generate_cartesian_shepp_logan_dataset.py
+++ b/generate_cartesian_shepp_logan_dataset.py
@@ -15,7 +15,7 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
 
     # Oversample if needed
     if oversampling>1:
-        padding = (oversampling*phan.shape[1] - phan.shape[1])/2
+        padding = round((oversampling*phan.shape[1] - phan.shape[1])/2)
         phan = np.pad(phan,((0,0),(padding,padding)),mode='constant')
         csm = np.pad(csm,((0,0),(0,0),(padding,padding)),mode='constant')
         coil_images = np.pad(coil_images,((0,0),(0,0),(padding,padding)),mode='constant')
@@ -81,13 +81,13 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     
     limits1 = ismrmrd.xsd.limitType()
     limits1.minimum = 0
-    limits1.center = ny/2
+    limits1.center = round(ny/2)
     limits1.maximum = ny - 1
     limits.kspace_encoding_step_1 = limits1
     
     limits_rep = ismrmrd.xsd.limitType()
     limits_rep.minimum = 0
-    limits_rep.center = repetitions / 2
+    limits_rep.center = round(repetitions / 2)
     limits_rep.maximum = repetitions - 1
     limits.repetition = limits_rep
     
@@ -117,7 +117,7 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     acq.resize(nkx, coils)
     acq.version = 1
     acq.available_channels = coils
-    acq.center_sample = nkx/2
+    acq.center_sample = round(nkx/2)
     acq.read_dir[0] = 1.0
     acq.phase_dir[1] = 1.0
     acq.slice_dir[2] = 1.0


### PR DESCRIPTION
numpy.pad requires integer pad_width (maybe as of python3?).  center and center_sample must also be integers, as required by ismrmrd.xsd and the ISMRMRD AcquisitionHeader respectively.