### PR TITLE
Update Sphinx pngmath to imgmath

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'numpydoc',


### PR DESCRIPTION
Sphinx's `pngmath` module is deprecated and I was unable to build the docs with this dependency requirement, this PR updates the configuration to use `sphinx.ext.imgmath`, its successor. 