### PR TITLE
Fixed ismrmrd.xsd referfences and array indexing

### DIFF
--- a/generate_cartesian_shepp_logan_dataset.py
+++ b/generate_cartesian_shepp_logan_dataset.py
@@ -43,24 +43,24 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     header.acquisitionSystemInformation = sys
 
     # Encoding
-    encoding = ismrmrd.xsd.encoding()
-    encoding.trajectory = ismrmrd.xsd.trajectoryType.cartesian
+    encoding = ismrmrd.xsd.encodingType()
+    encoding.trajectory = ismrmrd.xsd.trajectoryType.CARTESIAN
     
     # encoded and recon spaces
-    efov = ismrmrd.xsd.fieldOfView_mm()
+    efov = ismrmrd.xsd.fieldOfViewMm()
     efov.x = oversampling*256
     efov.y = 256
     efov.z = 5
-    rfov = ismrmrd.xsd.fieldOfView_mm()
+    rfov = ismrmrd.xsd.fieldOfViewMm()
     rfov.x = 256
     rfov.y = 256
     rfov.z = 5
     
-    ematrix = ismrmrd.xsd.matrixSize()
+    ematrix = ismrmrd.xsd.matrixSizeType()
     ematrix.x = nkx
     ematrix.y = nky
     ematrix.z = 1
-    rmatrix = ismrmrd.xsd.matrixSize()
+    rmatrix = ismrmrd.xsd.matrixSizeType()
     rmatrix.x = nx
     rmatrix.y = ny
     rmatrix.z = 1
@@ -107,7 +107,7 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     encoding.encodingLimits = limits
     header.encoding.append(encoding)
 
-    dset.write_xml_header(header.toxml('utf-8'))           
+    dset.write_xml_header(header.toXML('utf-8'))           
 
     # Synthesize the k-space data
     Ktrue = transform.transform_image_to_kspace(coil_images,(1,2))

--- a/recon_ismrmrd_dataset.py
+++ b/recon_ismrmrd_dataset.py
@@ -8,7 +8,7 @@ import numpy as np
 from ismrmrdtools import show, transform
 
 # Load file
-filename = '/tmp/testdata.h5'
+filename = 'testdata.h5'
 if not os.path.isfile(filename):
     print("%s is not a valid file" % filename)
     raise SystemExit
@@ -77,11 +77,11 @@ for acqnum in range(firstacq,dset.number_of_acquisitions()):
     # Remove oversampling if needed
     if eNx != rNx:
         xline = transform.transform_kspace_to_image(acq.data, [1])
-        x0 = (eNx - rNx) / 2
-        x1 = (eNx - rNx) / 2 + rNx
+        x0 = int((eNx - rNx) / 2)
+        x1 = int((eNx - rNx) / 2 + rNx)
         xline = xline[:,x0:x1]
         acq.resize(rNx,acq.active_channels,acq.trajectory_dimensions)
-        acq.center_sample = rNx/2
+        acq.center_sample = int(rNx/2)
         # need to use the [:] notation here to fill the data
         acq.data[:] = transform.transform_image_to_kspace(xline, [1])
   


### PR DESCRIPTION
In generate_cartesian_shepp_logan_dataset.py, fixed broken usages of ismrmrd.xsd
In recon_ismrmrd_dataset.py, fixed array indexing (was attempting to index with a float, now it uses integers).